### PR TITLE
Fix fonts not copied to public folder

### DIFF
--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -103,6 +103,15 @@ module.exports = {
       },
       to: config.outputs.image.filename,
     }]),
+    new CopyPlugin([{
+      context: config.paths.fonts,
+      from: {
+        glob: `${config.paths.fonts}/**/*`,
+        flatten: true,
+        dot: false
+      },
+      to: config.outputs.font.filename,
+    }]),
   ]
 }
 


### PR DESCRIPTION
Currently, font exists in `resources/fonts/*` not copied into `public/fonts` (or as configured). This pull request add a copy rule to the webpack config to do so.